### PR TITLE
Updated to phantomjs@1.9.20.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "fs-extra": "0.6.3",
     "lodash": "2.4.0",
-    "phantomjs": "1.9.15",
+    "phantomjs": "1.9.20",
     "rsvp": "3.0.15",
     "@filamentgroup/worker-farm": "1.2.0"
   },


### PR DESCRIPTION
This phantomjs release switches the default download CDN to GitHub releases, which is more reliable than BitBucket or cnpmjs. 

Unit tests seem to be passing.